### PR TITLE
Align Implementation and cmake against latest thunder code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,15 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.3)
+project(DRMNagra)
 
-include(${CMAKE_SYSROOT}${CMAKE_INSTALL_PREFIX}/include/cmake/WPEFramework.cmake)
+find_package(WPEFramework)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/")
 
-find_package(Core REQUIRED)
-find_package(Interfaces REQUIRED)
-
-include_directories(${CORE_INCLUDE_DIR} ${INTERFACES_INCLUDE_DIR})
+find_package(${NAMESPACE}Core REQUIRED)
 
 add_subdirectory(MediaSystem)
 add_subdirectory(MediaConnect)

--- a/MediaConnect/CMakeLists.txt
+++ b/MediaConnect/CMakeLists.txt
@@ -17,16 +17,30 @@
 
 project(DRMNagraConnect)
 
-set(DRM_PLUGIN_SOURCES 
-    MediaSessionConnect.cpp 
+set(MODULE_NAME NagraConnect)
+
+# add the library
+add_library(${MODULE_NAME} SHARED
+    MediaSessionConnect.cpp
     MediaConnect.cpp
     ../ParsePSSHHeader.cpp)
 
-# add the library
-add_library(${PROJECT_NAME} SHARED ${DRM_PLUGIN_SOURCES})
-target_link_libraries(${PROJECT_NAME} ${CORE_LIBRARIES})
-add_compiler_flags(${PROJECT_NAME} "${CORE_DEFINITIONS}")
-set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".drm")
-set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
+set_target_properties(${MODULE_NAME} PROPERTIES
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED YES)
 
-install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/${NAMESPACE}/OCDM)
+target_include_directories(${MODULE_NAME}
+    PRIVATE
+    "${CMAKE_SYSROOT}/usr/include"
+    "${CMAKE_SYSROOT}/usr/include/${NAMESPACE}"
+    ${NAGRA_INCLUDE_DIRS})
+
+target_link_libraries(${MODULE_NAME}
+    ${NAMESPACE}Core::${NAMESPACE}Core)
+
+add_compiler_flags(${MODULE_NAME} "${CORE_DEFINITIONS}")
+set_target_properties(${MODULE_NAME} PROPERTIES SUFFIX ".drm")
+set_target_properties(${MODULE_NAME} PROPERTIES PREFIX "")
+
+install(TARGETS ${MODULE_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/${NAMESPACE}/OCDM)
+

--- a/MediaConnect/MediaSessionConnect.cpp
+++ b/MediaConnect/MediaSessionConnect.cpp
@@ -25,8 +25,8 @@ namespace {
 class MediaSystemLoader {
     public:
     MediaSystemLoader() 
-        : _SessionSystem(nullptr)
-        , _syslib("DRMNagraSystem.drm") {
+        : _syslib("DRMNagraSystem.drm")
+        , _SessionSystem(nullptr) {
 
         if (_syslib.IsLoaded() == true) {
             _SessionSystem = reinterpret_cast<CDMi::IMediaSessionSystem*(*)(const char*)>(_syslib.LoadFunction(_T("GetMediaSessionSystemInterface")));

--- a/MediaSystem/CMakeLists.txt
+++ b/MediaSystem/CMakeLists.txt
@@ -17,21 +17,33 @@
 
 project(DRMNagraSystem)
 
-set(DRM_PLUGIN_SOURCES 
-    MediaSessionSystem.cpp 
+find_package(Nagra REQUIRED)
+
+set(MODULE_NAME NagraSystem)
+
+# add the library
+add_library(${MODULE_NAME} SHARED
+    MediaSessionSystem.cpp
     MediaSystem.cpp
     OperatorVault.cpp
     ../ParsePSSHHeader.cpp)
 
-find_package(Nagra REQUIRED)
+set_target_properties(${MODULE_NAME} PROPERTIES
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED YES)
 
-include_directories(${NAGRA_INCLUDE_DIRS})
+target_include_directories(${MODULE_NAME}
+    PRIVATE
+    "${CMAKE_SYSROOT}/usr/include"
+    "${CMAKE_SYSROOT}/usr/include/${NAMESPACE}"
+    ${NAGRA_INCLUDE_DIRS})
 
-# add the library
-add_library(${PROJECT_NAME} SHARED ${DRM_PLUGIN_SOURCES})
-target_link_libraries(${PROJECT_NAME} ${NAGRA_LIBRARIES} ${CORE_LIBRARIES})
-add_compiler_flags(${PROJECT_NAME} "${CORE_DEFINITIONS}")
-set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".drm")
-set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
+target_link_libraries(${MODULE_NAME}
+    ${NAGRA_LIBRARIES}
+    ${NAMESPACE}Core::${NAMESPACE}Core)
 
-install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/${NAMESPACE}/OCDM)
+add_compiler_flags(${MODULE_NAME} "${CORE_DEFINITIONS}")
+set_target_properties(${MODULE_NAME} PROPERTIES SUFFIX ".drm")
+set_target_properties(${MODULE_NAME} PROPERTIES PREFIX "")
+
+install(TARGETS ${MODULE_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/${NAMESPACE}/OCDM)

--- a/MediaSystem/MediaSystem.cpp
+++ b/MediaSystem/MediaSystem.cpp
@@ -20,6 +20,8 @@
 #include <core/core.h>
 #include "../Report.h"
 
+using namespace WPEFramework;
+
 namespace CDMi {
 
 namespace {

--- a/MediaSystem/MediaSystem.cpp
+++ b/MediaSystem/MediaSystem.cpp
@@ -99,7 +99,7 @@ public:
     ~NagraSystem() {
     }
 
-   void OnSystemConfigurationAvailable(const std::string& configline) {
+   void Initialize(PluginHost::IShell* /* shell */,  const std::string& configline) {
         Config config; 
         config.FromString(configline);
         _operatorvaultpath = config.OperatorVaultPath.Value();

--- a/MediaSystem/OperatorVault.cpp
+++ b/MediaSystem/OperatorVault.cpp
@@ -18,10 +18,12 @@
 
 #include "OperatorVault.h"
 
+using namespace WPEFramework;
+
 namespace CDMi {
 
 OperatorVault::OperatorVault(const string& path)
-    : _file(path) {
+    : _file(path, Core::File::USER_READ) {
 }
 
 string OperatorVault::LoadOperatorVault() const {


### PR DESCRIPTION
Current Nagra ocdm implementation is  not compilable against latest thunder code. Updated the code to make it compile. It is not tested, since platform is not available for the validation